### PR TITLE
Removing redundant jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery-2.1.3.min": "http://code.jquery.com/jquery-2.1.3.min.js",
     "foundation-sites": "^6.2.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@
   </footer>
   <!-- Scripts -->
   
-  <script src="./lib/jquery-2.1.3.min/index.js"></script>
+  <script src="./lib/jquery/dist/jquery.min.js"></script>
   <script src="./lib/foundation-sites/dist/foundation.min.js"></script>
   <script src="./js/script.js"></script>
   <script>


### PR DESCRIPTION
Foundation installs jquery so we don't have to.